### PR TITLE
add worker to cache wranglerjs binary

### DIFF
--- a/cache-wranglerjs-binary/.gitignore
+++ b/cache-wranglerjs-binary/.gitignore
@@ -1,0 +1,10 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log
+worker/
+node_modules/
+.cargo-ok
+.prettierrc

--- a/cache-wranglerjs-binary/index.js
+++ b/cache-wranglerjs-binary/index.js
@@ -1,0 +1,34 @@
+/**
+ * This Worker is responsible for caching wranglerjs binaries.
+ */
+
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request))
+})
+
+/**
+ * Fetch and log a request
+ * @param {Request} request
+ */
+async function handleRequest(request) {
+  let urlParts = /^https?:\/\/workers\.cloudflare\.com\/get\-wranglerjs\-binary\/([^\/]+)\/([^\/]+)\.tar\.gz/.exec(request.url)
+  if (!urlParts) {
+    return new Response("Missing URL components", {status: 400})
+  }
+
+  let toolName, version
+  [_, toolName, version] = urlParts
+
+  console.log(urlParts)
+
+  if (version[0] == 'v') {
+    version = version.substring(1)
+  }
+
+  return fetch(`https://github.com/cloudflare/wrangler/releases/download/v${version}/${toolName}-v${version}.tar.gz`, {
+    cf: {
+      cacheEverything: true,
+      cacheTtl: 3600
+    }
+  })
+}

--- a/cache-wranglerjs-binary/package.json
+++ b/cache-wranglerjs-binary/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "cache-wranglerjs-binary",
+  "version": "1.0.0",
+  "description": "Downloads and caches wranglerjs binaries from GitHub",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format": "prettier --write '**/*.{js,css,json,md}'"
+  },
+  "author": "Gabbi Fisher <gabbi@cloudflare.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "prettier": "^1.18.2"
+  }
+}

--- a/cache-wranglerjs-binary/wrangler.toml
+++ b/cache-wranglerjs-binary/wrangler.toml
@@ -1,0 +1,6 @@
+account_id = "8995c0f49cdcf57eb54d2c1e52b7d2f3"
+name = "cache-wranglerjs-binary"
+type = "js"
+route = "https://workers.cloudflare.com/get-wranglerjs-binary*"
+workers_dev = false
+zone_id = "29ed9c83c2c78d6967876c4053ec8154"


### PR DESCRIPTION
This is the second worker used to cache binaries. This one is for wranglerjs binaries.