### PR TITLE
Cache responses from GitHub and use a GitHub OAuth token

### DIFF
--- a/cache-npm-wrangler-binary/index.js
+++ b/cache-npm-wrangler-binary/index.js
@@ -6,6 +6,13 @@ async function getJSONFromGitHub(url) {
   return fetch(url, {
     headers: {
       "User-Agent": "Workers",
+      "Authorization": `token ${GITHUB_TOKEN}`,
+    },
+    cf: {
+      cacheEverything: true,
+      cacheTtlByStatus: {
+        "200": 300,
+      }
     },
   })
     .then(async (res) => {


### PR DESCRIPTION
I added a GitHub OAuth token from my GitHub account. It doesn't have any special auth scopes to make it work – literally any token will do.

I tested that this works using `wrangler dev` and logging relevant headers:

```
cf-cache-status: EXPIRED
x-ratelimit-remaining: 4988
x-ratelimit-used: 12
x-ratelimit-reset: 1602783240
cf-cache-status: EXPIRED
x-ratelimit-remaining: 4987
x-ratelimit-used: 13
x-ratelimit-reset: 1602783240
[2020-10-15 12:03:15] GET workers.cloudflare.com/get-npm-wrangler-binary/1.11.0/x86_64-unknown-linux-musl HTTP/1.1 200 OK
cf-cache-status: HIT
x-ratelimit-remaining: 4988
x-ratelimit-used: 12
x-ratelimit-reset: 1602783240
cf-cache-status: HIT
x-ratelimit-remaining: 4987
x-ratelimit-used: 13
x-ratelimit-reset: 1602783240
[2020-10-15 12:03:22] GET workers.cloudflare.com/get-npm-wrangler-binary/1.11.0/x86_64-unknown-linux-musl HTTP/1.1 200 OK
```