### PR TITLE
feat: add support for downloading pre-built aarch64 wrangler dependency binaries

### DIFF
--- a/cache-dependency-binary/index.js
+++ b/cache-dependency-binary/index.js
@@ -23,6 +23,18 @@ async function handleRequest(request) {
     version = version.substring(1)
   }
 
+  if (target === 'aarch64-apple-darwin') {
+    const asset = `${toolName}-${version}-${target}.tar.gz`
+    const body = await WRANGLER_AARCH64_DEPS.get(asset)
+    
+    return new Response(body, { headers: {
+      'content-length': body.length,
+      'content-type': 'application/octet-stream',
+      'accept-ranges': 'bytes',
+      'content-disposition': `attachment; filename=${asset}`
+    }})
+  }
+
   let ownersToToolNames = new Map()
   ownersToToolNames.set("ashleygwilliams", ["cargo-generate"])
   ownersToToolNames.set("rustwasm", ["wasm-pack"])

--- a/cache-dependency-binary/wrangler.toml
+++ b/cache-dependency-binary/wrangler.toml
@@ -4,3 +4,6 @@ type = "javascript"
 route = "https://workers.cloudflare.com/get-binary*"
 workers_dev = false
 zone_id = "29ed9c83c2c78d6967876c4053ec8154"
+kv_namespaces = [
+  { binding = "WRANGLER_AARCH64_DEPS", id = "aa7af0771c6e4b578f399dcf8436db75" }
+]


### PR DESCRIPTION
Includes target inspection to determine requirement of `aarch64` download, which are stored in new KV namespace. 